### PR TITLE
Add doctor/labtech roles and order workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# WomSoft Server
+
+This project exposes a small FastAPI service used for demo purposes. Users are stored in a SQLite database and JWT is used for authentication.
+
+## Roles
+
+Users now include a `role` field. Supported roles are:
+
+- `admin`
+- `doctor`
+- `labtech`
+- regular `user`
+
+Administrators can access the admin endpoints. Doctors can create test orders which are later fulfilled by lab technicians.
+
+## Test Order Workflow
+
+1. A doctor calls `POST /api/orders/` with the patient name to create a new order.
+2. A lab technician calls `POST /api/orders/{order_id}/fulfill` with diagnostic values to generate results and mark the order as fulfilled.
+3. Orders can be listed with `GET /api/orders/`.
+
+Run the tests with:
+
+```bash
+pytest -q
+```

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from app.database import engine, Base, get_db
 from app.auth.router import router as auth_router
 from app.routers.diagnostics import router as diagnostics_router
 from app.routers.admin import router as admin_router  # Add this import
+from app.routers.orders import router as orders_router
 from app.middleware.audit_middleware import AuditMiddleware  # Add this import
 from app.models.user import User
 from app.auth.jwt import get_password_hash
@@ -29,6 +30,7 @@ templates = Jinja2Templates(directory="templates")
 app.include_router(auth_router)
 app.include_router(diagnostics_router)
 app.include_router(admin_router)  # Add this line
+app.include_router(orders_router)
 
 # Root route
 @app.get("/")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .user import User
+from .diagnostic import Diagnostic
+from .audit import AuditLog
+from .order import TestOrder

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base
+
+class TestOrder(Base):
+    __tablename__ = "test_orders"
+
+    id = Column(Integer, primary_key=True, index=True)
+    patient_name = Column(String, nullable=False)
+    doctor_id = Column(Integer, ForeignKey("users.id"))
+    lab_tech_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    diagnostic_id = Column(Integer, ForeignKey("diagnostics.id"), nullable=True)
+    status = Column(String, default="pending")
+
+    doctor = relationship("User", foreign_keys=[doctor_id])
+    lab_tech = relationship("User", foreign_keys=[lab_tech_id])
+    diagnostic = relationship("Diagnostic")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -9,4 +9,5 @@ class User(Base):
     username = Column(String, unique=True, index=True)
     email = Column(String, unique=True, index=True)
     hashed_password = Column(String)
+    role = Column(String, default="user")
     audit_logs = relationship("AuditLog", back_populates="user")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from .diagnostics import router as diagnostics_router
+from .admin import router as admin_router
+from .orders import router as orders_router

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.database import get_db
+from app.auth.jwt import get_current_user
+from app.models.user import User
+from app.models.order import TestOrder
+from app.models.diagnostic import Diagnostic
+from app.schemas.order import OrderCreate, Order
+from app.schemas.diagnostic import DiagnosticCreate
+from .diagnostics import calculate_diagnostic_result
+
+router = APIRouter(prefix="/api/orders", tags=["orders"])
+
+
+def require_role(role: str):
+    def checker(user: User = Depends(get_current_user)):
+        if user.role != role:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+        return user
+    return checker
+
+
+@router.post("/", response_model=Order)
+async def create_order(
+    order_in: OrderCreate,
+    db: Session = Depends(get_db),
+    doctor: User = Depends(require_role("doctor"))
+):
+    order = TestOrder(patient_name=order_in.patient_name, doctor_id=doctor.id)
+    db.add(order)
+    db.commit()
+    db.refresh(order)
+    return order
+
+
+@router.post("/{order_id}/fulfill", response_model=Order)
+async def fulfill_order(
+    order_id: int,
+    diag_in: DiagnosticCreate,
+    db: Session = Depends(get_db),
+    labtech: User = Depends(require_role("labtech"))
+):
+    order = db.query(TestOrder).filter(TestOrder.id == order_id).first()
+    if not order or order.status != "pending":
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    result = calculate_diagnostic_result(diag_in.protein1, diag_in.protein2, diag_in.protein3)
+    diagnostic = Diagnostic(
+        identifier=diag_in.identifier,
+        protein1=diag_in.protein1,
+        protein2=diag_in.protein2,
+        protein3=diag_in.protein3,
+        result=result,
+        user_id=labtech.id
+    )
+    db.add(diagnostic)
+    db.commit()
+    db.refresh(diagnostic)
+
+    order.diagnostic_id = diagnostic.id
+    order.lab_tech_id = labtech.id
+    order.status = "fulfilled"
+    db.commit()
+    db.refresh(order)
+    return order
+
+
+@router.get("/", response_model=List[Order])
+async def list_orders(
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user)
+):
+    return db.query(TestOrder).all()

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+from .user import User, UserCreate, Token
+from .diagnostic import Diagnostic, DiagnosticCreate
+from .order import Order, OrderCreate

--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Optional
+from .diagnostic import Diagnostic
+
+class OrderCreate(BaseModel):
+    patient_name: str
+
+class Order(BaseModel):
+    id: int
+    patient_name: str
+    doctor_id: int
+    lab_tech_id: Optional[int]
+    diagnostic_id: Optional[int]
+    status: str
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 class UserBase(BaseModel):
     username: str
     email: str
+    role: str = "user"
 
 class UserCreate(UserBase):
     password: str

--- a/tests/integration/test_orders.py
+++ b/tests/integration/test_orders.py
@@ -1,0 +1,23 @@
+import pytest
+
+class TestOrders:
+    def test_doctor_creates_and_labtech_fulfills_order(self, client, doctor_token_headers, labtech_token_headers):
+        # Doctor creates order
+        order_data = {"patient_name": "John Doe"}
+        resp = client.post("/api/orders/", json=order_data, headers=doctor_token_headers)
+        assert resp.status_code == 200
+        order_id = resp.json()["id"]
+
+        # Lab technician fulfills order
+        diag_data = {
+            "identifier": "ORD-1",
+            "protein1": 1.0,
+            "protein2": 2.0,
+            "protein3": 3.0
+        }
+        resp = client.post(f"/api/orders/{order_id}/fulfill", json=diag_data, headers=labtech_token_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "fulfilled"
+        assert body["diagnostic_id"] is not None
+


### PR DESCRIPTION
## Summary
- extend `User` model with `role`
- introduce `TestOrder` model and API router for doctors and labtechs
- provide Pydantic schemas for orders
- expose new order routes in main app
- update tests to use roles and cover basic order lifecycle
- document new roles and workflow in README

## Testing
- `pytest -q tests/unit tests/integration/test_api_endpoints.py tests/integration/test_audit_logging.py tests/integration/test_orders.py`
- `pytest -q` *(fails: selenium WebDriver Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e76967f588329acbb33f28cbd1b1f